### PR TITLE
Enable mouse_snap in Wayfire

### DIFF
--- a/etc/wayfire/defaults.ini
+++ b/etc/wayfire/defaults.ini
@@ -18,7 +18,7 @@ slot_l = <ctrl><alt>KEY_LEFT
 slot_r = <ctrl><alt>KEY_RIGHT
 slot_c = <ctrl><alt>KEY_UP
 restore = <ctrl><alt>KEY_DOWN
-mouse_snap = false
+mouse_snap = true
 
 [autostart]
 autostart_wf_shell = false


### PR DESCRIPTION
This PR enables snapping windows then moved to screen borders. This is a feature users have come to expect from other operating systems and desktop environments.

References:
* https://github.com/WayfireWM/wayfire/discussions/2018
* https://github.com/RPi-Distro/pi-gen/pull/729